### PR TITLE
fix bug Delegater没有对应的构造函数，只有一个new方法，该bug会导致读取一个默认值的struct时，抛异常

### DIFF
--- a/tars.js
+++ b/tars.js
@@ -1103,7 +1103,7 @@ Tars.TarsInputStream.prototype.readString = function (tag, require, DEFAULT_VALU
 }
 
 Tars.TarsInputStream.prototype.readStruct = function (tag, require, TYPE_T) {
-    if (this._skipToTag(tag, require) == false) { return  new TYPE_T(); }
+    if (this._skipToTag(tag, require) == false) { return  TYPE_T.new(this); }
 
     var head = this._readFrom();
     if (head.type != Tars.DataHelp.EN_STRUCTBEGIN) {


### PR DESCRIPTION
fix bug Delegater没有对应的构造函数，只有一个new方法，该bug会导致读取一个默认值的struct时，抛异常